### PR TITLE
Fix Transporter dupe.

### DIFF
--- a/Kits/src/com/gmail/nuclearcat1337/kits/Transporter.java
+++ b/Kits/src/com/gmail/nuclearcat1337/kits/Transporter.java
@@ -434,6 +434,7 @@ class Teleporter
 			w.playEffect(state1.getLocation(), Effect.STEP_SOUND, 153);
 			//w.playSound(state1.getLocation(), sound, volume, pitch) The sound
 			this.state1.update(true);
+			this.state1 = null;
 		}
 		if(state2 != null)
 		{
@@ -441,6 +442,7 @@ class Teleporter
 			w.playEffect(state2.getLocation(), Effect.STEP_SOUND, 153);
 			//w.playSound(state2.getLocation(), sound, volume, pitch) The sound
 			this.state2.update(true);
+			this.state2 = null;
 		}
 	}
 	


### PR DESCRIPTION
Fixes dupe where placing 2 portal sides, breaking them, then create 1 portal side and break that one updates state of other side.

Example of dupe:

Right click on a random block
  ![Right clicking block](http://i.imgur.com/XOpG9Dl.png)
Then on the block you want to dupe
  ![Two portals](http://i.imgur.com/trTuQrI.png)
Break the portal by punching it
  ![Broken portals](http://i.imgur.com/hnnFjY4.png)
Mine the block you wanted to dupe
  ![Broken duped block](http://i.imgur.com/D3IM2fx.png)
Right click another random block and destroy the new portal
   ![New portal](http://i.imgur.com/K1eEWI6.png)
Once destroyed block you right clicked second at start will reappear, 
  ![Resetted](http://i.imgur.com/f914WQc.png)
And process can be repeated

This PR will fix this by resetting the BlockStates of the teleporter.
